### PR TITLE
.gitignore ignore file compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ Thumbs.db
 core
 *.log
 *.zip
+/compile_commands.json
+


### PR DESCRIPTION
Reasons:
* Used for clangd C++ LSP server.
* Created by kdesrc-build.