### PR TITLE
session_state fix issue "'result < 0' is always false"

### DIFF
--- a/src/session_state.c
+++ b/src/session_state.c
@@ -827,7 +827,7 @@ int session_state_deserialize_protobuf(session_state **state, Textsecure__Sessio
     }
 
     if(session_structure->senderchain) {
-        session_state_deserialize_protobuf_sender_chain(
+        result = session_state_deserialize_protobuf_sender_chain(
                 result_state->session_version,
                 &result_state->sender_chain, session_structure->senderchain,
                 global_context);


### PR DESCRIPTION
Fix PVS-Studio issue src/session_state.c:834: warning: V547 Expression 'result < 0' is always false.